### PR TITLE
GA: use Gemfile.lock in bundle install

### DIFF
--- a/.github/workflows/update_json.yml
+++ b/.github/workflows/update_json.yml
@@ -21,7 +21,7 @@ jobs:
         git clone --depth 50 https://github.com/aozorabunko/aozorabunko.git
     - name: use bunlder
       run: |
-        cp Gemfile aozorabunko/
+        cp Gemfile Gemfile.lock aozorabunko/
         cd aozorabunko && bundle install
     - name: generate person.json
       run: |


### PR DESCRIPTION
`bundle install` する際にこのリポジトリに追加したGemfile.lockを使うようにします。